### PR TITLE
Validate DEEPSEEK_API_KEY and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment configuration
+# API key for DeepSeek (required)
+DEEPSEEK_API_KEY=
+
+# API key for Google Custom Search (optional)
+GOOGLE_SEARCH_API_KEY=
+CUSTOM_SEARCH_ENGINE_ID=
+
+# API key for Yandex SpeechKit (optional)
+YANDEX_SPEECHKIT_API_KEY=
+
+# Telegram bot token (optional)
+TELEGRAM_BOT_TOKEN=
+
+# OpenAI API key (optional)
+OPENAI_API_KEY=
+
+# Healthchecks.io ping URL (optional)
+HEALTHCHECKS_PING_URL=
+# Heartbeat interval in seconds (optional, default is 300)
+HEARTBEAT_INTERVAL_SEC=300

--- a/llm_manager.py
+++ b/llm_manager.py
@@ -42,6 +42,8 @@ class LLMManager:
     Класс для управления и выбора языковых моделей.
     """
     def __init__(self):
+        if not DEEPSEEK_API_KEY:
+            raise RuntimeError("DEEPSEEK_API_KEY is missing")
         self.deepseek_client = OpenAI(
             api_key=DEEPSEEK_API_KEY,
             base_url="https://api.deepseek.com/v1"


### PR DESCRIPTION
## Summary
- Ensure LLMManager raises an error when DEEPSEEK_API_KEY is missing
- Provide .env.example documenting required and optional environment variables

## Testing
- `python -m py_compile llm_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0aaa184148321950afb507469582c