### PR TITLE
Ensure updated .env values override and note restart

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,8 @@ import os
 from dotenv import load_dotenv
 
 # Загружаем переменные из .env файла
-load_dotenv()
+# После изменения .env файл сервис нужно перезапустить, чтобы обновить значения
+load_dotenv(override=True)
 
 # Ключи для API
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()


### PR DESCRIPTION
## Summary
- allow `.env` values to override existing environment variables
- document need to restart the service after changing `.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab8bea3883218431c37cbeb879a7