### PR TITLE
Fix env loading for LLMManager

### DIFF
--- a/llm_manager.py
+++ b/llm_manager.py
@@ -1,15 +1,16 @@
 import os
 import asyncio
-from openai import OpenAI # Библиотека openai теперь используется для работы с DeepSeek
+from openai import OpenAI  # Библиотека openai теперь используется для работы с DeepSeek
 from googleapiclient.discovery import build
 import logging
 import re
 
-# Импортируем наши ключи из переменных окружения
-DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
-GOOGLE_SEARCH_API_KEY = os.getenv("GOOGLE_SEARCH_API_KEY")
-CUSTOM_SEARCH_ENGINE_ID = os.getenv("CUSTOM_SEARCH_ENGINE_ID")
-YANDEX_SPEECHKIT_API_KEY = os.getenv("YANDEX_SPEECHKIT_API_KEY")
+# Импортируем ключи через модуль config, который заранее загружает переменные окружения
+from config import (
+    DEEPSEEK_API_KEY,
+    GOOGLE_SEARCH_API_KEY,
+    CUSTOM_SEARCH_ENGINE_ID,
+)
 
 # Класс для работы с поисковиком Google
 class GoogleSearch:


### PR DESCRIPTION
## Summary
- import API keys in `llm_manager` via `config` so `.env` values load properly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import os
os.environ['DEEPSEEK_API_KEY'] = 'test'
from llm_manager import LLMManager
LLMManager()
print('init ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c0aec0141083218fc94a4b717d1f09